### PR TITLE
CONNECTION_CLOSE reason as a hex string

### DIFF
--- a/TypeScript/draft-01/QLog.ts
+++ b/TypeScript/draft-01/QLog.ts
@@ -890,7 +890,7 @@ export interface IConnectionCloseFrame{
     error_space:ErrorSpace;
     error_code:TransportError | ApplicationError | CryptoError | string | number;
     raw_error_code:number;
-    reason:string;
+    reason:string; // hex
 
     trigger_frame_type?:number; // TODO: should be more defined, but we don't have a FrameType enum atm...
 }


### PR DESCRIPTION
The Reason in a CONNECTION_CLOSE is not necessarily encodable as a string, so just represent it as hex